### PR TITLE
Add search model to settings fields

### DIFF
--- a/src/marqo_commons/settings_validation/settings_validation.py
+++ b/src/marqo_commons/settings_validation/settings_validation.py
@@ -48,6 +48,15 @@ def validate_index_settings(settings_to_validate: dict, MAX_NUMBER_OF_REPLICAS: 
                         NsFields.model_properties: {
                             "type": "object",
                         },
+                        NsFields.search_model: {
+                            "type": "string",
+                            "examples": [
+                                "hf/all_datasets_v4_MiniLM-L6"
+                            ]
+                        },
+                        NsFields.search_model_properties: {
+                            "type": "object",
+                        },
                         NsFields.normalize_embeddings: {
                             "type": "boolean",
                             "examples": [

--- a/src/marqo_commons/shared_utils/enums.py
+++ b/src/marqo_commons/shared_utils/enums.py
@@ -29,6 +29,8 @@ class IndexSettingsField:
     treat_urls_and_pointers_as_images = "treat_urls_and_pointers_as_images"
     model = "model"
     model_properties = "model_properties"
+    search_model = "search_model"
+    search_model_properties = "search_model_properties"
     normalize_embeddings = "normalize_embeddings"
 
     text_preprocessing = "text_preprocessing"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -104,6 +104,24 @@ class TestValidateIndexSettings(TestCase):
                                                         MAX_NUMBER_OF_REPLICAS=
                                                         self.MARQO_MAX_NUMBER_OF_REPLICAS,
                                                         )
+        
+    def test_validate_index_settings_search_model(self):
+        good_settings = self.get_good_index_settings()
+        good_settings['index_defaults']['model_properties'] = {
+            "dimensions": 123,
+            "url": "https://random_site.com"
+        }
+        good_settings['index_defaults']['search_model'] = "ViT-B/32"
+        good_settings['index_defaults']['search_model_properties'] = {
+            "dimensions": 456,
+            "url": "https://random_site.com"
+        }
+        assert good_settings == validate_index_settings(good_settings,
+                                                        MAX_EF_CONSTRUCTION_VALUE=
+                                                        self.MARQO_EF_CONSTRUCTION_MAX_VALUE,
+                                                        MAX_NUMBER_OF_REPLICAS=
+                                                        self.MARQO_MAX_NUMBER_OF_REPLICAS,
+                                                        )
 
     def test_validate_index_settings_bad(self):
         bad_settings = [{


### PR DESCRIPTION
Adds `search_model` and `search_model_properties` as:
1. members of `IndexSettingsField` enum
2. non-required fields in settings object schema.

This is required for search model feature: https://github.com/marqo-ai/marqo/issues/622